### PR TITLE
Downgrades workflow to known successful rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-04-28
         override: true
     - run: rustup component add rust-src
     - name: Build


### PR DESCRIPTION
Downgrades the rust version to the version which
the last successful job used.
This is a stop-gap measure while we wait for
our dependencies to fix errors with the newest nightly.

Fixes #38 