### PR TITLE
Removed specific version override

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2021-04-28
+        toolchain: nightly
         override: true
     - run: rustup component add rust-src
     - name: Build


### PR DESCRIPTION
As all dependencies now build on latest stable,
we can use the latest nightly again.

Fixes #40 