### PR TITLE
Fixes workflow using nightly without rustfmt

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         profile: minimal
         toolchain: nightly
+        components: rustfmt
         override: true
-    - run: rustup component add rustfmt --toolchain nightly
     - name: rustfmt
       run: cargo +nightly fmt --all -- --check


### PR DESCRIPTION
Using `components: rustfmt` makes GitHub install the latest nightly that has the `rustfmt` component.

Fixes #49 