### PR TITLE
Fixes undefined symbol error on newest nightly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,3 +179,8 @@ fn panic_handler(info: &PanicInfo) -> ! {
 	}
 	loop {}
 }
+
+#[no_mangle]
+pub fn rust_oom() -> !  {
+	panic!("Hopefully, this should never be called");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,6 @@ fn panic_handler(info: &PanicInfo) -> ! {
 }
 
 #[no_mangle]
-pub fn rust_oom() -> !  {
+pub fn rust_oom() -> ! {
 	panic!("Hopefully, this should never be called");
 }


### PR DESCRIPTION
This is a horrible fix, but as the name of the 'missing' function is rust_oom,
it should hopefully never be called,
as we have full control over the allocator :)